### PR TITLE
Enable custom Sentry URL

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -33,6 +33,7 @@ workflows:
         run_if: true
         inputs:
         - sentry_auth_token: $sentry_auth_token
+        - sentry_url: $sentry_url
         - sentry_org_slug: $sentry_org_slug
         - sentry_project_slug: $sentry_project_slug
         - sentry_dsym_path: $sentry_dsym_path

--- a/step.sh
+++ b/step.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-sentry-cli --auth-token ${sentry_auth_token} --url ${sentry_url} upload-dif --org ${sentry_org_slug} --project ${sentry_project_slug} ${sentry_dsym_path}
+sentry-cli --auth-token ${sentry_auth_token} --url ${sentry_url} upload-dif --org ${sentry_org_slug} --project ${sentry_project_slug} "${sentry_dsym_path}"

--- a/step.sh
+++ b/step.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-sentry-cli --auth-token ${sentry_auth_token} upload-dif --org ${sentry_org_slug} --project ${sentry_project_slug} ${sentry_dsym_path}
+sentry-cli --auth-token ${sentry_auth_token} --url ${sentry_url} upload-dif --org ${sentry_org_slug} --project ${sentry_project_slug} ${sentry_dsym_path}

--- a/step.yml
+++ b/step.yml
@@ -49,6 +49,13 @@ inputs:
       is_required: true
       is_expand: true
       is_sensitive: true
+  - sentry_url: https://sentry.io/
+    opts:
+      title: Server URL for Sentry
+      description: |
+        Fully qualified URL to the Sentry server.
+        [defaults to https://sentry.io/]
+      is_required: true
   - sentry_org_slug:
     opts:
       title: Org Slug for Sentry


### PR DESCRIPTION
This enables to configure custom Sentry URL which is required for self-hosted instances.

Furthermore this contains a small fix for file paths with white spaces.